### PR TITLE
Upgrade Sentry to v9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 # Add plugins here
+https://github.com/ianyamey/sentry-auth-google/zipball/master
+sentry-slack~=0.5.0


### PR DESCRIPTION
We had been using an older version of sentry forked from [aptible/docker-sentry](https://github.com/aptible/docker-sentry). This PR adds to a new fork of [getsentry/onpremise](https://github.com/getsentry/onpremise).

Changes:
* Copy over requirements.txt from [trialspark/docker-sentry](https://github.com/trialspark/docker-sentry)
* Update the README.md